### PR TITLE
Creating Makefiles for Heretic/Hexen/Strife and make it compile

### DIFF
--- a/Makefile.doom.wiiu
+++ b/Makefile.doom.wiiu
@@ -1,0 +1,136 @@
+#-------------------------------------------------------------------------------
+.SUFFIXES:
+#-------------------------------------------------------------------------------
+
+ifeq ($(strip $(DEVKITPRO)),)
+$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/devkitpro")
+endif
+
+TOPDIR ?= $(CURDIR)
+
+include $(DEVKITPRO)/wut/share/wut_rules
+
+#-------------------------------------------------------------------------------
+# TARGET is the name of the output
+# BUILD is the directory where object files & intermediate files will be placed
+# SOURCES is a list of directories containing source code
+# DATA is a list of directories containing data files
+# INCLUDES is a list of directories containing header files
+#-------------------------------------------------------------------------------
+TARGET		:=	$(notdir $(CURDIR))
+BUILD		:=	build-doom
+SOURCES		:=	src src/doom opl src/wiiu
+DATA		:=	wiiu-data
+INCLUDES	:=	src src/doom opl src/wiiu
+
+#-------------------------------------------------------------------------------
+# options for code generation
+#-------------------------------------------------------------------------------
+CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
+			$(MACHDEP)
+
+CFLAGS	+=	$(INCLUDE) -D__WIIU__ -D__WUT__ \
+			-DBETTER_ANALOG -DBETTER_JOYWAIT
+
+CXXFLAGS	:= $(CFLAGS)
+
+ASFLAGS	:=	-g $(ARCH)
+LDFLAGS	=	-g $(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map)
+
+LIBS	:= -lSDL2_mixer -lmpg123 -lmodplug -lvorbisidec -logg `sdl2-config --libs` -lm -lstdc++ -lwut
+
+#-------------------------------------------------------------------------------
+# list of directories containing libraries, this must be the top level
+# containing include and lib
+#-------------------------------------------------------------------------------
+LIBDIRS	:= $(PORTLIBS) $(WUT_ROOT)
+
+#-------------------------------------------------------------------------------
+# no real need to edit anything past this point unless you need to add additional
+# rules for different file extensions
+#-------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#-------------------------------------------------------------------------------
+
+export OUTPUT	:=	$(CURDIR)/$(TARGET)
+export TOPDIR	:=	$(CURDIR)
+
+export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
+			$(foreach dir,$(DATA),$(CURDIR)/$(dir))
+
+export DEPSDIR	:=	$(CURDIR)/$(BUILD)
+
+CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
+SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+
+#-------------------------------------------------------------------------------
+# use CXX for linking C++ projects, CC for standard C
+#-------------------------------------------------------------------------------
+ifeq ($(strip $(CPPFILES)),)
+#-------------------------------------------------------------------------------
+	export LD	:=	$(CC)
+#-------------------------------------------------------------------------------
+else
+#-------------------------------------------------------------------------------
+	export LD	:=	$(CXX)
+#-------------------------------------------------------------------------------
+endif
+#-------------------------------------------------------------------------------
+
+export OFILES_BIN	:=	$(addsuffix .o,$(BINFILES))
+export OFILES_SRC	:=	$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+export OFILES 	:=	$(OFILES_BIN) $(OFILES_SRC)
+export HFILES_BIN	:=	$(addsuffix .h,$(subst .,_,$(BINFILES)))
+
+export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
+			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+			-I$(CURDIR)/$(BUILD) \
+			-I$(PORTLIBS_PATH)/wiiu/include/SDL2
+
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
+.PHONY: $(BUILD) clean all
+
+#-------------------------------------------------------------------------------
+all: $(BUILD)
+
+$(BUILD):
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile.doom.wiiu
+
+#-------------------------------------------------------------------------------
+clean:
+	@echo clean ...
+	@rm -fr $(BUILD) $(TARGET).rpx $(TARGET).elf
+
+#-------------------------------------------------------------------------------
+else
+.PHONY:	all
+
+DEPENDS	:=	$(OFILES:.o=.d)
+
+#-------------------------------------------------------------------------------
+# main targets
+#-------------------------------------------------------------------------------
+all	:	$(OUTPUT).rpx
+
+$(OUTPUT).rpx	:	$(OUTPUT).elf
+$(OUTPUT).elf	:	$(OFILES)
+
+$(OFILES_SRC)	: $(HFILES_BIN)
+
+#-------------------------------------------------------------------------------
+# you need a rule like this for each extension you use as binary data
+#-------------------------------------------------------------------------------
+%.bin.o	%_bin.h :	%.bin
+#-------------------------------------------------------------------------------
+	@echo $(notdir $<)
+	@$(bin2o)
+
+-include $(DEPENDS)
+
+#-------------------------------------------------------------------------------
+endif
+#-------------------------------------------------------------------------------

--- a/Makefile.heretic.wiiu
+++ b/Makefile.heretic.wiiu
@@ -1,0 +1,136 @@
+#-------------------------------------------------------------------------------
+.SUFFIXES:
+#-------------------------------------------------------------------------------
+
+ifeq ($(strip $(DEVKITPRO)),)
+$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/devkitpro")
+endif
+
+TOPDIR ?= $(CURDIR)
+
+include $(DEVKITPRO)/wut/share/wut_rules
+
+#-------------------------------------------------------------------------------
+# TARGET is the name of the output
+# BUILD is the directory where object files & intermediate files will be placed
+# SOURCES is a list of directories containing source code
+# DATA is a list of directories containing data files
+# INCLUDES is a list of directories containing header files
+#-------------------------------------------------------------------------------
+TARGET		:=	crispy-heretic
+BUILD		:=	build-heretic
+SOURCES		:=	src src/heretic opl src/wiiu textscreen
+DATA		:=	wiiu-data
+INCLUDES	:=	src src/heretic opl src/wiiu textscreen
+
+#-------------------------------------------------------------------------------
+# options for code generation
+#-------------------------------------------------------------------------------
+CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
+			$(MACHDEP)
+
+CFLAGS	+=	$(INCLUDE) -D__WIIU__ -D__WUT__ \
+			-DBETTER_ANALOG -DBETTER_JOYWAIT
+
+CXXFLAGS	:= $(CFLAGS)
+
+ASFLAGS	:=	-g $(ARCH)
+LDFLAGS	=	-g $(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map)
+
+LIBS	:= -lSDL2_mixer -lmpg123 -lmodplug -lvorbisidec -logg `sdl2-config --libs` -lm -lstdc++ -lwut
+
+#-------------------------------------------------------------------------------
+# list of directories containing libraries, this must be the top level
+# containing include and lib
+#-------------------------------------------------------------------------------
+LIBDIRS	:= $(PORTLIBS) $(WUT_ROOT)
+
+#-------------------------------------------------------------------------------
+# no real need to edit anything past this point unless you need to add additional
+# rules for different file extensions
+#-------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#-------------------------------------------------------------------------------
+
+export OUTPUT	:=	$(CURDIR)/$(TARGET)
+export TOPDIR	:=	$(CURDIR)
+
+export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
+			$(foreach dir,$(DATA),$(CURDIR)/$(dir))
+
+export DEPSDIR	:=	$(CURDIR)/$(BUILD)
+
+CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
+SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+
+#-------------------------------------------------------------------------------
+# use CXX for linking C++ projects, CC for standard C
+#-------------------------------------------------------------------------------
+ifeq ($(strip $(CPPFILES)),)
+#-------------------------------------------------------------------------------
+	export LD	:=	$(CC)
+#-------------------------------------------------------------------------------
+else
+#-------------------------------------------------------------------------------
+	export LD	:=	$(CXX)
+#-------------------------------------------------------------------------------
+endif
+#-------------------------------------------------------------------------------
+
+export OFILES_BIN	:=	$(addsuffix .o,$(BINFILES))
+export OFILES_SRC	:=	$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+export OFILES 	:=	$(OFILES_BIN) $(OFILES_SRC)
+export HFILES_BIN	:=	$(addsuffix .h,$(subst .,_,$(BINFILES)))
+
+export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
+			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+			-I$(CURDIR)/$(BUILD) \
+			-I$(PORTLIBS_PATH)/wiiu/include/SDL2
+
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
+.PHONY: $(BUILD) clean all
+
+#-------------------------------------------------------------------------------
+all: $(BUILD)
+
+$(BUILD):
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile.heretic.wiiu
+
+#-------------------------------------------------------------------------------
+clean:
+	@echo clean ...
+	@rm -fr $(BUILD) $(TARGET).rpx $(TARGET).elf
+
+#-------------------------------------------------------------------------------
+else
+.PHONY:	all
+
+DEPENDS	:=	$(OFILES:.o=.d)
+
+#-------------------------------------------------------------------------------
+# main targets
+#-------------------------------------------------------------------------------
+all	:	$(OUTPUT).rpx
+
+$(OUTPUT).rpx	:	$(OUTPUT).elf
+$(OUTPUT).elf	:	$(OFILES)
+
+$(OFILES_SRC)	: $(HFILES_BIN)
+
+#-------------------------------------------------------------------------------
+# you need a rule like this for each extension you use as binary data
+#-------------------------------------------------------------------------------
+%.bin.o	%_bin.h :	%.bin
+#-------------------------------------------------------------------------------
+	@echo $(notdir $<)
+	@$(bin2o)
+
+-include $(DEPENDS)
+
+#-------------------------------------------------------------------------------
+endif
+#-------------------------------------------------------------------------------

--- a/Makefile.hexen.wiiu
+++ b/Makefile.hexen.wiiu
@@ -1,0 +1,136 @@
+#-------------------------------------------------------------------------------
+.SUFFIXES:
+#-------------------------------------------------------------------------------
+
+ifeq ($(strip $(DEVKITPRO)),)
+$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/devkitpro")
+endif
+
+TOPDIR ?= $(CURDIR)
+
+include $(DEVKITPRO)/wut/share/wut_rules
+
+#-------------------------------------------------------------------------------
+# TARGET is the name of the output
+# BUILD is the directory where object files & intermediate files will be placed
+# SOURCES is a list of directories containing source code
+# DATA is a list of directories containing data files
+# INCLUDES is a list of directories containing header files
+#-------------------------------------------------------------------------------
+TARGET		:=	crispy-hexen
+BUILD		:=	build-hexen
+SOURCES		:=	src src/hexen opl src/wiiu textscreen
+DATA		:=	wiiu-data
+INCLUDES	:=	src src/hexen opl src/wiiu textscreen
+
+#-------------------------------------------------------------------------------
+# options for code generation
+#-------------------------------------------------------------------------------
+CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
+			$(MACHDEP)
+
+CFLAGS	+=	$(INCLUDE) -D__WIIU__ -D__WUT__ \
+			-DBETTER_ANALOG -DBETTER_JOYWAIT
+
+CXXFLAGS	:= $(CFLAGS)
+
+ASFLAGS	:=	-g $(ARCH)
+LDFLAGS	=	-g $(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map)
+
+LIBS	:= -lSDL2_mixer -lmpg123 -lmodplug -lvorbisidec -logg `sdl2-config --libs` -lm -lstdc++ -lwut
+
+#-------------------------------------------------------------------------------
+# list of directories containing libraries, this must be the top level
+# containing include and lib
+#-------------------------------------------------------------------------------
+LIBDIRS	:= $(PORTLIBS) $(WUT_ROOT)
+
+#-------------------------------------------------------------------------------
+# no real need to edit anything past this point unless you need to add additional
+# rules for different file extensions
+#-------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#-------------------------------------------------------------------------------
+
+export OUTPUT	:=	$(CURDIR)/$(TARGET)
+export TOPDIR	:=	$(CURDIR)
+
+export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
+			$(foreach dir,$(DATA),$(CURDIR)/$(dir))
+
+export DEPSDIR	:=	$(CURDIR)/$(BUILD)
+
+CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
+SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+
+#-------------------------------------------------------------------------------
+# use CXX for linking C++ projects, CC for standard C
+#-------------------------------------------------------------------------------
+ifeq ($(strip $(CPPFILES)),)
+#-------------------------------------------------------------------------------
+	export LD	:=	$(CC)
+#-------------------------------------------------------------------------------
+else
+#-------------------------------------------------------------------------------
+	export LD	:=	$(CXX)
+#-------------------------------------------------------------------------------
+endif
+#-------------------------------------------------------------------------------
+
+export OFILES_BIN	:=	$(addsuffix .o,$(BINFILES))
+export OFILES_SRC	:=	$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+export OFILES 	:=	$(OFILES_BIN) $(OFILES_SRC)
+export HFILES_BIN	:=	$(addsuffix .h,$(subst .,_,$(BINFILES)))
+
+export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
+			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+			-I$(CURDIR)/$(BUILD) \
+			-I$(PORTLIBS_PATH)/wiiu/include/SDL2
+
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
+.PHONY: $(BUILD) clean all
+
+#-------------------------------------------------------------------------------
+all: $(BUILD)
+
+$(BUILD):
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile.hexen.wiiu
+
+#-------------------------------------------------------------------------------
+clean:
+	@echo clean ...
+	@rm -fr $(BUILD) $(TARGET).rpx $(TARGET).elf
+
+#-------------------------------------------------------------------------------
+else
+.PHONY:	all
+
+DEPENDS	:=	$(OFILES:.o=.d)
+
+#-------------------------------------------------------------------------------
+# main targets
+#-------------------------------------------------------------------------------
+all	:	$(OUTPUT).rpx
+
+$(OUTPUT).rpx	:	$(OUTPUT).elf
+$(OUTPUT).elf	:	$(OFILES)
+
+$(OFILES_SRC)	: $(HFILES_BIN)
+
+#-------------------------------------------------------------------------------
+# you need a rule like this for each extension you use as binary data
+#-------------------------------------------------------------------------------
+%.bin.o	%_bin.h :	%.bin
+#-------------------------------------------------------------------------------
+	@echo $(notdir $<)
+	@$(bin2o)
+
+-include $(DEPENDS)
+
+#-------------------------------------------------------------------------------
+endif
+#-------------------------------------------------------------------------------

--- a/Makefile.strife.wiiu
+++ b/Makefile.strife.wiiu
@@ -17,11 +17,11 @@ include $(DEVKITPRO)/wut/share/wut_rules
 # DATA is a list of directories containing data files
 # INCLUDES is a list of directories containing header files
 #-------------------------------------------------------------------------------
-TARGET		:=	$(notdir $(CURDIR))
-BUILD		:=	build
-SOURCES		:=	src src/doom opl src/wiiu
+TARGET		:=	crispy-strife
+BUILD		:=	build-strife
+SOURCES		:=	src src/strife opl src/wiiu textscreen
 DATA		:=	wiiu-data
-INCLUDES	:=	src src/doom opl src/wiiu
+INCLUDES	:=	src src/strife opl src/wiiu textscreen
 
 #-------------------------------------------------------------------------------
 # options for code generation
@@ -98,7 +98,7 @@ all: $(BUILD)
 
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile.wiiu
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile.strife.wiiu
 
 #-------------------------------------------------------------------------------
 clean:

--- a/README.md
+++ b/README.md
@@ -68,17 +68,19 @@ Get setup with [devkitPro](https://devkitpro.org/wiki/Getting_Started), and make
 Download necessary dependancies:
 
 ```bash
-(dkp-)pacman -S wiiu-sdl{,_mixer}
+(dkp-)pacman -S wiiu-sdl2{,_mixer}
+(dkp-)pacman -S ppc-libvorbisidec
 ```
 
 Build the executable:
 
 ```bash
-make -f Makefile.wiiu
+make -f Makefile.doom.wiiu
 ```
 
 NOTE: This repository is fully capable of building the original PC version as well. If you plan on doing so, I recommend `clean`ing the repository in between building the two different versions because the build system can get confused.
 
+NOTE2: Makefiles for Heretic/Hexen/Strife exist and while these compile they do not run yet on the Wii U. 
 ### The rest of the readme is the original Crispy Doom readme. Thanks for playing!
 
 # Crispy Doom

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -47,6 +47,10 @@
 #include "v_video.h"
 #include "v_trans.h" // [crispy] dp_translation
 
+#ifdef __WIIU__
+#include <whb/proc.h>
+#endif // __WIIU__
+
 #define CT_KEY_GREEN    'g'
 #define CT_KEY_YELLOW   'y'
 #define CT_KEY_RED      'r'
@@ -833,6 +837,7 @@ void D_BindVariables(void)
 
 static void D_Endoom(void)
 {
+#ifndef __WIIU__
     byte *endoom_data;
 
     // Disable ENDOOM?
@@ -845,6 +850,7 @@ static void D_Endoom(void)
     endoom_data = W_CacheLumpName(DEH_String("ENDTEXT"), PU_STATIC);
 
     I_Endoom(endoom_data);
+#endif // !__WIIU__
 }
 
 //---------------------------------------------------------------------------

--- a/src/strife/d_main.c
+++ b/src/strife/d_main.c
@@ -80,6 +80,10 @@
 
 #include "d_main.h"
 
+#ifdef __WIIU__
+#include <whb/proc.h>
+#endif // __WIIU__
+
 //
 // D-DoomLoop()
 // Not a globally visible function,
@@ -1100,6 +1104,7 @@ void PrintGameVersion(void)
 
 static void D_Endoom(void)
 {
+#ifndef __WIIU__
     byte *endoom;
 
     // Don't show ENDOOM if we have it disabled, or we're running
@@ -1116,6 +1121,7 @@ static void D_Endoom(void)
     endoom = W_CacheLumpName(DEH_String("ENDSTRF"), PU_STATIC);
 
     I_Endoom(endoom);
+#endif // !__WIIU__
 }
 
 //


### PR DESCRIPTION
- Adding Makefiles for Heretic/Hexen/Doom
- Adjusting buildpath so they won't interfere each other
- Commenting contents of D_Endoom() in d_main.c of Heretic and Strife to make it compile
- Adding a note to Readme
- Adding libiconv installation as prerequisite for compiling

Next steps should be adopting changes in doom src directory to the other 3 games to make them run successful on WiiU

fixes #2 